### PR TITLE
Rename Repository

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -89,8 +89,6 @@ jobs:
         uses: ./.github/actions/setup-dependencies
       - name: Run Unit Tests
         run: just test
-      - name: Override Coverage Source Path for SonarCloud
-        run: sed -i "s/<source>\/home\/runner\/work\/python-practice\/python-practice<\/source>/<source>\/github\/workspace<\/source>/g" /home/runner/work/python-practice/python-practice/coverage.xml
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Python Practice
+# Python Practise
 
 This is a collection of my Python code challenges and solutions.
 
 ## Table of Contents
 
-- [Python Practice](#python-practice)
+- [Python Practise](#python-practise)
   - [Table of Contents](#table-of-contents)
   - [Challenges](#challenges)
     - [LeetCode](#leetcode)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "python-practice"
+name = "python-practise"
 dynamic = ["version"]
 requires-python = ">=3.13"
 dependencies = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.organization=jackplowman
-sonar.projectKey=JackPlowman_python-practice
+sonar.projectKey=JackPlowman_python-practise
 
 sonar.sources=.
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several changes to the project, primarily focusing on renaming the project from "Python Practice" to "Python Practise" and removing an unnecessary step from the GitHub Actions workflow.

Project renaming:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R7): Updated the project name from "Python Practice" to "Python Practise" and adjusted the corresponding table of contents link.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2): Changed the project name to "python-practise".
* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL2-R2): Updated the `sonar.projectKey` to reflect the new project name.

Workflow simplification:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L92-L93): Removed the step that overrides the coverage source path for SonarCloud.