### PR TITLE
Regularly Clear Caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -1,0 +1,24 @@
+name: Clean Caches
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  clean-caches:
+    name: Clean GitHub Action Caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Delete caches
+        run: gh cache delete --all --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to clean caches on a scheduled basis. The workflow is designed to run on the first day of each month and can also be triggered manually.

Key changes include:

* Added a new workflow file `.github/workflows/clean-caches.yml` to define the cache cleaning process:
  * Scheduled to run on the first day of each month at midnight.
  * Can be manually triggered via `workflow_dispatch`.
  * Configured with read-only permissions for repository contents.
  * Includes a job named `clean-caches` that runs on `ubuntu-latest`.
  * Steps include checking out the repository and deleting all caches using the GitHub CLI.