### PR TITLE
Pin GitHub Actions 2

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -5,12 +5,12 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@v5.4.0
+      uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
       with:
         pyproject-file: "pyproject.toml"
         enable-cache: true
     - name: Set up Just
-      uses: extractions/setup-just@v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python Dependencies
       shell: bash
       run: just install

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -89,7 +89,7 @@ jobs:
       - name: Run Unit Tests
         run: just test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.1.0
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.3
+        uses: UmbrellaDocs/action-linkspector@3e12ade1e0b1823455dae8cf8b4f9cc92ec7dd20 # v1.3.3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -137,7 +137,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.0
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
         with:
           version: "latest"
       - name: Run Lefthook Validate

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,7 +21,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows by replacing version tags with specific commit SHAs for better reliability and reproducibility. These changes ensure that the workflows always use the exact same version of the actions, even if upstream tags are modified.

### Updates to GitHub Actions workflows:

#### Workflow `.github/actions/setup-dependencies/action.yml`:
* Updated `astral-sh/setup-uv` to use commit SHA `22695119d769bdb6f7032ad67b9bca0ef8c4a174` instead of version `v5.4.0`.
* Updated `extractions/setup-just` to use commit SHA `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` instead of version `v3.0.0`.

#### Workflow `.github/workflows/code-checks.yml`:
* Updated `super-linter/super-linter/slim` to use commit SHA `4e8a7c2bf106c4c766c816b35ec612638dc9b6b2` instead of version `v7.3.0`.
* Updated `SonarSource/sonarqube-scan-action` to use commit SHA `aa494459d7c39c106cc77b166de8b4250a32bb97` instead of version `v5.1.0`.
* Updated `UmbrellaDocs/action-linkspector` to use commit SHA `3e12ade1e0b1823455dae8cf8b4f9cc92ec7dd20` instead of version `v1.3.3`.
* Updated `extractions/setup-just` to use commit SHA `e33e0265a09d6d736e2ee1e0eb685ef1de4669ff` instead of version `v3.0.0`.
* Updated `astral-sh/setup-uv` to use commit SHA `22695119d769bdb6f7032ad67b9bca0ef8c4a174` instead of version `v5.4.0`.

#### Workflow `.github/workflows/pull-request-tasks.yml`:
* Updated `pascalgn/size-label-action` to use commit SHA `f8edde36b3be04b4f65dcfead05dc8691b374348` instead of version `v0.5.5`.

#### Workflow `.github/workflows/sync-labels.yml`:
* Updated `micnncim/action-label-syncer` to use commit SHA `3abd5ab72fda571e69fffd97bd4e0033dd5f495c` instead of version `v1.3.0`.