### PR TITLE
Bump GitHub Action Versions

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -5,10 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-      with:
-        pyproject-file: "pyproject.toml"
-        enable-cache: true
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python Dependencies

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@3e12ade1e0b1823455dae8cf8b4f9cc92ec7dd20 # v1.3.3
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -137,9 +137,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
-        with:
-          version: "latest"
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
       - name: Run Lefthook Validate
         run: uvx lefthook validate
 
@@ -159,12 +157,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.13
+        uses: github/codeql-action/init@v3.28.17
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.13
+        uses: github/codeql-action/analyze@v3.28.17
 
   run-zizmor:
     name: Check GitHub Actions with zizmor
@@ -184,7 +182,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.13
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies and actions used in GitHub workflows to their latest versions, ensuring compatibility and incorporating the latest features and fixes. The changes primarily focus on updating versions of actions in `.github/actions/setup-dependencies/action.yml` and `.github/workflows/code-checks.yml`.

### Dependency Updates

* Updated `astral-sh/setup-uv` from version `v5.4.0` to `v6.0.1` in both `.github/actions/setup-dependencies/action.yml` and `.github/workflows/code-checks.yml` to ensure compatibility with the latest features. [[1]](diffhunk://#diff-41744aaf34820b46fe17d53d97ac7b6e435996a46c06a1781154ead9701846daL8-R8) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L140-R140)

* Updated `UmbrellaDocs/action-linkspector` from version `v1.3.3` to `v1.3.4` in `.github/workflows/code-checks.yml` for improved Markdown link checking.

* Updated `github/codeql-action` actions (`init`, `analyze`, and `upload-sarif`) from version `v3.28.13` to `v3.28.17` in `.github/workflows/code-checks.yml` to incorporate the latest security and quality improvements. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L162-R165) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L187-R185)