### PR TITLE
Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,15 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -22,9 +26,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` file to enhance the configuration of dependency updates. The changes include adding timezone specifications, refining group rules, and excluding certain patterns for updates.

### Enhancements to Dependabot configuration:

* Added a `timezone` field to specify "Europe/London" for the update schedule. (`.github/dependabot.yml`, [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R11-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R29-R33)

### Refinements to group rules:

* For the `github-actions` group:
  - Introduced an `applies-to` field with the value "version-updates".
  - Added `exclude-patterns` to exclude updates matching "super-linter/*".
  
* For the `python` group:
  - Introduced an `applies-to` field with the value "version-updates".