### PR TITLE
Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -175,10 +175,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Dependencies
-        uses: ./.github/actions/setup-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/Justfile
+++ b/Justfile
@@ -106,7 +106,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the code-checking workflow and the `Justfile` to use new tools and commands for running checks. The changes include replacing the dependency setup action, introducing `uv` and `Just` tools, and modifying the commands for running `zizmor` checks.

### Workflow updates:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L178-R183): Replaced the `setup-dependencies` action with `astral-sh/setup-uv` (v6.0.1) and `extractions/setup-just` (v3). Updated the `Run zizmor` step to use the `just` tool with the `zizmor-check-sarif` command instead of directly invoking `uv`.

### Command updates:
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL109-R113): Added a new `zizmor-check-sarif` command that uses `uvx` to run `zizmor` with SARIF output. The existing `zizmor-check` command was also updated to use `uvx` instead of the previous `zizmor` invocation.