### PR TITLE
Change Jobs to Common Code Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -40,6 +40,16 @@ jobs:
           VALIDATE_PYTHON_RUFF: false
           VALIDATE_PYTHON_PYINK: false
 
+  common-code-checks:
+    name: Common Code Checks
+    permissions:
+      contents: read
+      pull-requests: read
+      security-events: write
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
+
   run-python-code-checks:
     name: Run Python Code Checks
     runs-on: ubuntu-latest
@@ -92,53 +102,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  check-markdown-links:
-    name: Check Markdown links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
-        with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configurations/.linkspector.yml
-          reporter: github-pr-review
-          fail_on_error: true
-          filter_mode: nofilter
-          show_stats: true
-
-  check-justfile-format:
-    name: Check Justfile Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Check Justfile Format
-        run: just format-check
-
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate
-
   run-codeql-analysis:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
@@ -161,28 +124,3 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-
-  run-zizmor:
-    name: Check GitHub Actions with zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
-      - name: Set up Just
-        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
-      - name: Run zizmor 🌈
-        run: just zizmor-check-sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
-        with:
-          sarif_file: results.sarif
-          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the `.github/workflows/code-checks.yml` file to streamline and consolidate code checks by introducing a reusable workflow and removing several redundant or less-used jobs.

### Consolidation of code checks:
* Added a new `common-code-checks` job that uses the reusable workflow `JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml` to centralize common code checks. This simplifies the workflow and reduces duplication.

### Removal of specific jobs:
* Removed the `check-markdown-links` job, which validated Markdown links using the `UmbrellaDocs/action-linkspector` action.
* Removed the `check-justfile-format` job, which validated the format of `Justfile` using the `extractions/setup-just` action.
* Removed the `lefthook-validate` job, which validated Lefthook configurations using the `astral-sh/setup-uv` action.
* Removed the `run-zizmor` job, which checked GitHub Actions with `zizmor` and uploaded SARIF results.