### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -10,7 +10,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 dependencies:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the label configuration for markdown files in the `.github/other-configurations/labeller.yml` file. The change corrects the spelling of the license file pattern in the configuration.

* Label configuration: Changed the file pattern from `LICENSE` to `LICENCE` in the markdown label section to match the correct filename.