### PR TITLE
Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   common-pull-request-tasks:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small change to the GitHub Actions workflow configuration by updating the `permissions` setting.

- Changed the `permissions` field in `.github/workflows/pull-request-tasks.yml` from specifying `pull-requests: read` to an empty object, effectively removing explicit permissions.