### PR TITLE
Update Reusable Workflows

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Python and UV
-      uses: astral-sh/setup-uv@4959332f0f014c5280e7eac8b70c90cb574c9f9b # v6.6.0
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
     - name: Set up Just
       uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3.0.0
     - name: Install Python Dependencies

--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@69995069a0036cef69ac3cc2abf89f1376053a52 # v2025.08.26.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@69995069a0036cef69ac3cc2abf89f1376053a52 # v2025.08.26.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -48,7 +48,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+        uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -118,7 +118,7 @@ jobs:
       - name: Run Unit Tests
         run: just test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 # v5.3.0
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -131,6 +131,6 @@ jobs:
     strategy:
       matrix:
         language: [actions, python]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@69995069a0036cef69ac3cc2abf89f1376053a52 # v2025.08.26.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     with:
       language: ${{ matrix.language }}

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -11,6 +11,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@69995069a0036cef69ac3cc2abf89f1376053a52 # v2025.08.26.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@69995069a0036cef69ac3cc2abf89f1376053a52 # v2025.08.26.01
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@a5950751b77827654b888eb6b52a5c7fbca3e4fa # v2025.09.30.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use newer versions of reusable workflows and key third-party actions. The changes ensure that the CI/CD pipeline benefits from the latest features, bug fixes, and security improvements.

**Reusable workflow updates:**

* Updated all references to the `JackPlowman/reusable-workflows` repository in `.github/workflows/clean-caches.yml`, `.github/workflows/code-checks.yml`, `.github/workflows/pull-request-tasks.yml`, and `.github/workflows/sync-labels.yml` to use version `v2025.09.30.01` instead of `v2025.08.26.01`. This brings in updates and improvements from the reusable workflow templates. [[1]](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L26-R26) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L134-R134) [[4]](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL14-R14) [[5]](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L19-R19)

**Third-party action version bumps:**

* Updated `astral-sh/setup-uv` in `.github/actions/setup-dependencies/action.yml` from `v6.6.0` to `v6.8.0`, ensuring the latest Python and UV setup improvements are included.
* Updated `github/codeql-action/upload-sarif` in `.github/workflows/code-checks.yml` from `v3.29.11` to `v3.30.5` for uploading SARIF analysis results.
* Updated `SonarSource/sonarqube-scan-action` in `.github/workflows/code-checks.yml` from `v5.3.0` to `v6.0.0`, bringing in the latest SonarCloud scanning features and fixes.